### PR TITLE
Prefer to keep the package repo

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,11 @@
+name: TagBot
+on:
+  schedule:
+    - cron: 13 3 * * *
+jobs:
+  TagBot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pkg"registry add <repository url>"
 ```
 This only needs to be done once per Julia installation.
 
-## Add a Package
+## Register a Package
 
 ```
 using LocalRegistry
@@ -78,7 +78,7 @@ Notes:
 * There is no checking that the dependencies are available in any
   registry.
 
-## Add a New Version of a Package
+## Register a New Version of a Package
 
 ```
 using LocalRegistry

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -108,7 +108,7 @@ by `package`.
     register(package, registry; commit = true, repo = nothing, gitconfig = Dict())
 
 * `commit`: If `false`, only make the changes to the registry but do not commit.
-* `repo`: Specify the package repository explicitly. Otherwise looked up as the `git remote` of the package.
+* `repo`: Specify the package repository explicitly. Otherwise looked up as the `git remote` of the package the first time it is registered.
 * `gitconfig`: Optional configuration parameters for the `git` command.
 """
 function register(package::Union{Module, AbstractString},

--- a/test/project_files/Flux32.toml
+++ b/test/project_files/Flux32.toml
@@ -1,0 +1,46 @@
+name = "Flux"
+uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+version = "0.10.7"
+
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+AbstractTrees = "0.2, 0.3"
+Adapt = "1"
+CodecZlib = "0.5, 0.6"
+Colors = "0.8, 0.9"
+CuArrays = "1.6"
+Juno = "0.5, 0.6, 0.7"
+MacroTools = "0.3, 0.4, 0.5"
+NNlib = "0.6"
+Reexport = "0.2"
+StatsBase = "0"
+ZipFile = "0.7, 0.8, 0.9"
+Zygote = "0.4"
+julia = "1"
+
+[extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Documenter"]

--- a/test/project_files/Flux33.toml
+++ b/test/project_files/Flux33.toml
@@ -1,0 +1,46 @@
+name = "Flux"
+uuid = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+version = "0.10.8"
+
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+AbstractTrees = "0.2, 0.3"
+Adapt = "1"
+CodecZlib = "0.5, 0.6"
+Colors = "0.8, 0.9"
+CuArrays = "1.6"
+Juno = "0.5, 0.6, 0.7"
+MacroTools = "0.3, 0.4, 0.5"
+NNlib = "0.6"
+Reexport = "0.2"
+StatsBase = "0"
+ZipFile = "0.7, 0.8, 0.9"
+Zygote = "0.4"
+julia = "1"
+
+[extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Documenter"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,6 +235,17 @@ pkg = Pkg.Types.read_project(joinpath(package_path, "Project.toml"))
 @test find_registry_path(nothing, pkg) == joinpath(first(DEPOT_PATH),
                                                    "registries", "TestRegistry")
 
+# Workaround for bad `mtime` resolution of 1 second on MacOS workers
+# on Travis.
+#
+# The issue is that `read_registry` caches its results with respect to
+# the file `mtime`. Since `read_registry` is called from within
+# `register`, the old data will be read into the cache. If the new
+# data is written close enough to the previous registry update so that
+# `mtime` does not change, subsequent `read_registry` will keep using
+# the old data from the cache.
+sleep(1)
+
 # More than one registry contains the package.
 register("FirstTest", "TestRegistry2",
          repo = "file://$(packages_dir)/FirstTest",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,26 @@ prepare_package(packages_dir, "Broken5.toml")
 @test_throws ErrorException register(joinpath(packages_dir, "Broken"),
                                      registry_dir, gitconfig = TEST_GITCONFIG)
 
+# Change the git remote before registration and verify that the
+# registered repo is not changed.
+prepare_package(packages_dir, "Flux32.toml")
+package_dir = joinpath(packages_dir, "Flux")
+git = gitcmd(package_dir, TEST_GITCONFIG)
+package_file = joinpath(registry_dir, "F", "Flux", "Package.toml")
+old_repo = TOML.parsefile(package_file)["repo"]
+new_repo = "https://example.com/Julia/Flux.jl.git"
+run(`$git remote set-url origin $(new_repo)`)
+register(joinpath(packages_dir, "Flux"), registry_dir,
+         gitconfig = TEST_GITCONFIG)
+@test TOML.parsefile(package_file)["repo"] == old_repo
+
+# Register with explicit repo argument and verify that the registered
+# repo is updated.
+prepare_package(packages_dir, "Flux33.toml")
+register(joinpath(packages_dir, "Flux"), registry_dir, repo = new_repo,
+         gitconfig = TEST_GITCONFIG)
+@test TOML.parsefile(package_file)["repo"] == new_repo
+
 pop!(LOAD_PATH)
 
 
@@ -204,11 +224,11 @@ corrupt_path = joinpath(package_path, "no_such_dir")
 
 # Find a registry by name.
 pkg = Pkg.Types.read_project(joinpath(package_path, "Project.toml"))
-@test find_registry_path("TestRegistry", pkg) == joinpath(first(DEPOT_PATH),
-                                                          "registries",
-                                                          "TestRegistry")
+@test find_registry_path("TestRegistry") == joinpath(first(DEPOT_PATH),
+                                                     "registries",
+                                                     "TestRegistry")
 
-# The named registry does not contain the package.
+# The named registry does not exist.
 @test_throws ErrorException find_registry_path("General", pkg)
 
 # Find which registry contains a package.
@@ -222,7 +242,7 @@ register("FirstTest", "TestRegistry2",
 @test_throws ErrorException find_registry_path(nothing, pkg)
 
 # Dirty the registry repository and try to register a package.
-registry_path = find_registry_path("TestRegistry2", pkg)
+registry_path = find_registry_path("TestRegistry2")
 filename = joinpath(registry_path, "Registry.toml")
 open(filename, "a") do io
     write(io, "\n")


### PR DESCRIPTION
* Do not update the package repo unless provided as an explicit argument to register.
* Only look up the git remote when registering a new package.
