### PR TITLE
Add push keyword argument.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"


### PR DESCRIPTION
This PR adds the option to automatically push registry changes to the repository, implemented as a keyword argument for `create_registry` and `register`. At the moment the default is not to push but that will most likely be changed some time soon.
