### PR TITLE
Support registering packages in subdirectories of a git repository.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,16 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-RegistryTools = "1.3"
+RegistryTools = "1.4"
 julia = "1.1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -89,44 +89,8 @@ When adding a new version of a package, the registry can be
 omitted. The new version number is obtained from the `version` field
 of the package's `Project.toml` file.
 
-## Working with a Private Registry and/or Private Repositories
+## Advanced Topics
 
-If the registry needs to be private and/or privately hosted packages are 
-added to it, using the git ssh protocol works well with Julia's Pkg manager:
 
-### 1. Add Packages to the Registry with the git ssh url Protocol
-
-Activate the private registry in Julia with the `git@github.com:...` 
-url format
-```
-using Pkg
-pkg"registry add git@github.com:User/CustomRegistry.git"
-```
-
-Adding a private package to the registry with the `git@github.com:...`
-url format
-```
-using LocalRegistry
-register(package, registry, repo="git@github.com:User/Package.jl.git")
-```
-
-### 2. Set Up Persistent git ssh Authentication that Julia Recognizes
-
-By default libssh2 (which is used by the Julia Pkg manager via libgit2)
-looks for git ssh keys in ~/.ssh/id_rsa and ~/.ssh/id_rsa.pub so if you 
-have that typical setup you shouldn't need to do anything extra. 
-
-If that doesn't work, or if your git keys need to be named differently, 
-you can try to set `SSH_PUB_KEY_PATH` and `SSH_KEY_PATH` environmental 
-variables:
-
-In Juno, setting “Julia Options” > “Arguments” to:
-```
-SSH_PUB_KEY_PATH=~/.ssh/key.pub, SSH_KEY_PATH=~/.ssh/key
-```
-or in `~/.bashrc`, for instance
-```
-export SSH_PUB_KEY_PATH=~/.ssh/key.pub
-export SSH_KEY_PATH=~/.ssh/key
-```
-
+* [Working with a Private Registry and/or Private Repositories](docs/ssh_keys.md)
+* [Registering a Package in a Subdirectory of a Repository](docs/subdir.md)

--- a/docs/ssh_keys.md
+++ b/docs/ssh_keys.md
@@ -1,0 +1,40 @@
+# Working with a Private Registry and/or Private Repositories
+
+If the registry needs to be private and/or privately hosted packages are
+added to it, using the git ssh protocol works well with Julia's Pkg manager:
+
+## 1. Add Packages to the Registry with the git ssh url Protocol
+
+Activate the private registry in Julia with the `git@github.com:...`
+url format
+```
+using Pkg
+pkg"registry add git@github.com:User/CustomRegistry.git"
+```
+
+Adding a private package to the registry with the `git@github.com:...`
+url format
+```
+using LocalRegistry
+register(package, registry, repo="git@github.com:User/Package.jl.git")
+```
+
+## 2. Set Up Persistent git ssh Authentication that Julia Recognizes
+
+By default libssh2 (which is used by the Julia Pkg manager via libgit2)
+looks for git ssh keys in ~/.ssh/id_rsa and ~/.ssh/id_rsa.pub so if you
+have that typical setup you shouldn't need to do anything extra.
+
+If that doesn't work, or if your git keys need to be named differently,
+you can try to set `SSH_PUB_KEY_PATH` and `SSH_KEY_PATH` environmental
+variables:
+
+In Juno, setting “Julia Options” > “Arguments” to:
+```
+SSH_PUB_KEY_PATH=~/.ssh/key.pub, SSH_KEY_PATH=~/.ssh/key
+```
+or in `~/.bashrc`, for instance
+```
+export SSH_PUB_KEY_PATH=~/.ssh/key.pub
+export SSH_KEY_PATH=~/.ssh/key
+```

--- a/docs/subdir.md
+++ b/docs/subdir.md
@@ -1,0 +1,40 @@
+# Registering a Package in a Subdirectory of a Repository
+
+A Julia package is normally a git repository by itself. However,
+sometimes you may want to have multiple packages in one repository or
+the Julia package is only a part of a larger repository. In those
+cases you need to be able to register only a subdirectory of the
+repository. This is fully supported by LocalRegistry and partially
+supported by Julia 1.0-1.4, as explained in the following
+sections. Julia support will be improved with version 1.5.
+
+## Register
+
+In order to register a package in a subdirectory of a repository you
+need to make the following preparations:
+
+* `git clone` the repository manually if you have not already done
+  so. It does not matter where the repository is placed.
+* `Pkg.develop` the package by path. E.g.
+```
+pkg"develop /path/to/repository/path/to/package"
+```
+
+After this, `register` can be called as normal.
+
+## Julia support
+
+In Julia 1.0-1.4, packages in subdirectories work as expected in the
+following contexts:
+
+* As dependencies to other packages.
+* `Pkg.add` by name from registry, e.g. `pkg"add Package"`
+* `Pkg.add` by name and version from registry, e.g. `pkg"add Package@1.1.0"`
+* `Pkg.dev` by path (using the full path to the subdirectory)
+
+The following do not work properly or at all:
+* `Pkg.add` by path
+* `Pkg.add` by name and branch from registry, e.g. `pkg"add Package#master"`
+* `Pkg.dev` by name
+
+This situation will be improved in Julia 1.5.

--- a/test/project_files/SubdirTest1.toml
+++ b/test/project_files/SubdirTest1.toml
@@ -1,0 +1,3 @@
+name = "SubdirTest"
+uuid = "809b6f6b-3c9f-4c56-9377-f6bfde4ecc2f"
+version = "0.1.0"

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,19 +7,23 @@ using Pkg: Pkg, TOML
 # Strictly speaking it is only the "Project.toml" file and the src
 # file that matter. Additional files are added to make the set up
 # somewhat more normal looking.
-function prepare_package(packages_dir, project_file)
+function prepare_package(packages_dir, project_file, subdir = "")
     project_file = joinpath(@__DIR__, "project_files", project_file)
     project_data = TOML.parsefile(project_file)
     name = project_data["name"]
     version = project_data["version"]
     # Fake repository URL.
     repo = "git@example.com:Julia/$(name).jl.git"
-    package_dir = joinpath(packages_dir, name)
+    top_dir = joinpath(packages_dir, name)
+    package_dir = joinpath(top_dir, subdir)
     mkpath(package_dir)
     mkpath(joinpath(package_dir, "src"))
     mkpath(joinpath(package_dir, "test"))
-    git = gitcmd(package_dir, TEST_GITCONFIG)
-    if !isdir(joinpath(package_dir, ".git"))
+    if !isempty(subdir)
+        write(joinpath(top_dir, "README.md"), "# Top Level README")
+    end
+    git = gitcmd(top_dir, TEST_GITCONFIG)
+    if !isdir(joinpath(top_dir, ".git"))
         run(`$(git) init -q`)
         run(`$git remote add origin $repo`)
     end


### PR DESCRIPTION
Implementation of #8. This mostly required new computation of tree hashes and dirty checks for only a subdirectory, and bumping RegistryTools.
