### PR TITLE
Remove some type restrictions

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -126,8 +126,8 @@ by `package`.
 * `repo`: Specify the package repository explicitly. Otherwise looked up as the `git remote` of the package the first time it is registered.
 * `gitconfig`: Optional configuration parameters for the `git` command.
 """
-function register(package::Union{Module, AbstractString},
-                  registry::Union{Nothing, AbstractString} = nothing;
+function register(package,
+                  registry = nothing;
                   commit = true, push = false, repo = nothing,
                   gitconfig::Dict = Dict())
     # Find and read the `Project.toml` for the package. First look for


### PR DESCRIPTION
I'd like to pass my own types in as `package` and `registry`. This works great - all I need to do is to define `find_package_path` and `find_registry_path` for my custom package type and custom registry type, respectively.

This PR removes the type restrictions on `package` and `registry`.

cc: @GunnarFarneback 