### PR TITLE
Return values for the `register` function: return `true` if a new release was registered

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -165,7 +165,7 @@ function register(package::Union{Module, AbstractString},
     # nothing and don't error in that case.
     if find_registered_version(pkg, registry_path) == tree_hash
         @info "This version has already been registered and is unchanged."
-        return
+        return false
     end
 
     # Use the `repo` argument or, if this is a new package
@@ -213,7 +213,7 @@ function register(package::Union{Module, AbstractString},
         error(explain_registration_error(status))
     end
 
-    return
+    return true
 end
 
 function explain_registration_error(status)


### PR DESCRIPTION
I've found that I need to distinguish between the following two cases:
1. This exact version of this package has already been registered
2. There is something new to register

In both of those cases, the `LocalRegistry.register` function will return `nothing`. It would be nice if `register` returned `true` if a new release was registered, and `false` otherwise.

So, for example, in case 1 `register` would return `false`. And in case 2 `register` would return `true`.