### PR TITLE
register returns false if check_and_update_registry_files fails

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -129,8 +129,7 @@ by `package`.
 function register(package::Union{Module, AbstractString},
                   registry::Union{Nothing, AbstractString} = nothing;
                   kwargs...)
-    do_register(package, registry; kwargs...)
-    return
+    return do_register(package, registry; kwargs...)
 end
 
 # Differs from the above by looser type restrictions on `package` and
@@ -220,6 +219,7 @@ function do_register(package, registry;
     # Registration failed. Explain to the user what happened.
     if haserror(status)
         error(explain_registration_error(status))
+        return false
     end
 
     return true


### PR DESCRIPTION
It would be nice to be able to determine if the update of the registry was succesful.  I realize now that I forgot to update the doc comment for `register`