### PR TITLE
Push registry after registrations by default.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ by name as strings. See the documentation string for more options.
 
 Notes:
 * You need to have a clean working copy of your registry.
-* The changes are committed to the registry but you need to push them
-  yourself.
 * The package must be stored as a git working copy, e.g. having been
   cloned with `Pkg.develop`.
 * The package must be available in the current `Pkg` environment.

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -101,10 +101,9 @@ from the package's `Project.toml`.
 Register a new version of the package in the currently active project.
 
 Notes:
- * By default this will, in all cases, only update the registry
-   locally. Review the result and `git push` it manually. This step
-   can be made automatically with the keyword argument `push`
-   described below.
+ * By default this will, in all cases, `git push` the updated registry
+   to its remote repository. If you prefer to do the push manually,
+   use the keyword argument `push = false`.
  * The package must live in a git working copy, e.g. having been
    cloned by `Pkg.develop`.
 
@@ -122,7 +121,7 @@ by `package`.
 
 *Keyword arguments*
 
-    register(package; registry = nothing, commit = true, push = false,
+    register(package; registry = nothing, commit = true, push = true,
              repo = nothing, gitconfig = Dict())
 
 * `registry`: Name or path of registry.
@@ -142,7 +141,7 @@ end
 # `registry`. Also returns false if there was nothing new to register
 # and true if something new was registered.
 function do_register(package, registry;
-                     commit = true, push = false, repo = nothing,
+                     commit = true, push = true, repo = nothing,
                      gitconfig::Dict = Dict())
     # Find and read the `Project.toml` for the package. First look for
     # the alternative `JuliaProject.toml`.


### PR DESCRIPTION
Change the default of the `push` keyword argument to `register` from `false` to `true`. Cf #30.