### PR TITLE
[Preview] Use jll version of git via Git package.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,16 @@ authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
 version = "0.4.0"
 
 [deps]
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Git = "1.2"
 RegistryTools = "1.4"
-julia = "~1.1, ~1.2, ~1.3, ~1.4, ~1.5, ~1.6, ~1.7"
+julia = "~1.6, ~1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -16,17 +16,8 @@ companion package
 
 ## Compatibility
 
-This package requires Julia 1.1 or later.
-
-## Prerequisites
-
-You need to have command line `git` installed and available in the
-system `PATH`. If
-```
-run(`git --version`)
-```
-in the Julia REPL prints a version number rather than giving an error,
-you are good to go.
+The latest version of this package requires Julia 1.6 or later. Old
+versions require Julia 1.1 or later.
 
 ## Installation
 

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -12,11 +12,12 @@ Registration of new and updated packages is done by the function `register`.
 """
 module LocalRegistry
 
-using RegistryTools: RegistryTools, gitcmd, Compress,
+using RegistryTools: RegistryTools, Compress,
                      check_and_update_registry_files, ReturnStatus, haserror,
                      find_registered_version
 using UUIDs: uuid4
 using Pkg: Pkg, TOML
+using Git
 
 export create_registry, register
 
@@ -432,6 +433,15 @@ function commit_registry(pkg::Pkg.Types.Project, package_path, package_repo, tre
     """
     run(`$git add --all`)
     run(`$git commit -qm $message`)
+end
+
+function gitcmd(path::AbstractString, gitconfig::Dict)
+    args = ["-C", path]
+    for (k, v) in gitconfig
+        push!(args, "-c")
+        push!(args, "$k=$v")
+    end
+    return Git.git(args)
 end
 
 end


### PR DESCRIPTION
This PR removes the prerequisite to have a working `git` installed in your `PATH` and instead employs the `Git` package to use a bundled `git` from the `git_jll` package.

However, the `Git` package requires a minimum Julia version of 1.6, which I don't want to impose on LocalRegistry just yet. There are some workarounds possible, but for now, to try this out, do (in Pkg mode):
```
pkg> add LocalRegistry#git_jll
```
