### PR TITLE
Check remote is bare when creating repo from path

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -207,7 +207,6 @@ function do_register(package, registry;
     clean_registry = true
 
     git = gitcmd(registry_path, gitconfig)
-
     HEAD = readchomp(`$git rev-parse --verify HEAD`)
     status = ReturnStatus()
     try
@@ -432,7 +431,7 @@ end
 
 function is_bare_repo(registry_path, gitconfig)
     git = gitcmd(registry_path, gitconfig)
-    parse(Bool, read(`$git  rev-parse --is-bare-repository`, String))
+    parse(Bool, read(`$git rev-parse --is-bare-repository`, String))
 end
 
 function commit_registry(pkg::Pkg.Types.Project, package_path, package_repo, tree_hash, git)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,7 +227,18 @@ register(joinpath(packages_dir, "FirstTest"), registry = registry_push_dir,
 @test readchomp(`$(downstream_git) log`) == readchomp(`$(upstream_git) log`)
 @test length(readlines(`$(upstream_git) log --format=oneline`)) == 2
 
-
+# Test it fails with an upstream repo that is not bare
+bad_upstream_dir = joinpath(testdir, "bad_upstream")
+mkpath(bad_upstream_dir)
+bad_upstream_git = gitcmd(bad_upstream_dir, TEST_GITCONFIG)
+run(`$(bad_upstream_git) init`)
+bad_registry_push_dir = joinpath(testdir, "TestRegistryNotBare")
+@test_throws ErrorException create_registry(
+    bad_registry_push_dir,
+    "file://$(bad_upstream_dir)",
+    push = true,
+    gitconfig = TEST_GITCONFIG
+)
 
 # Additional tests of `find_package_path` and `find_registry_path`.
 # Many of these have the purpose to cover error cases, making them


### PR DESCRIPTION
So this is not exactly elegant, but...

I can't figure out how to check if remote is bare. Instead, if the user specifies the remote URL as a path, it runs `git rev-parse` to check if the remote URL is bare.