### PR TITLE
Clarify that repository URL may also be path, and must be a bare repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ location for registries. Review the result and `git push` it
 manually. When created in this way the registry is automatically
 activated and the next section can be skipped.
 
+The repository at `repository_url` must be able to be pushed to,
+for example by being a bare repository. `repository_url` itself
+can be an URL, or a path to a local git repository.
+
 The registry can also be created at a specified path. See the
 documentation string for details.
 

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -27,12 +27,13 @@ export create_registry, register
     create_registry(path, repo)
 
 Create a registry with the given `name` or at the local directory
-`path`, and with repository URL `repo`. The first argument is
+`path`, and with repository URL or path `repo`. The first argument is
 interpreted as a path if it has more than one path component and
 otherwise as a name. If a path is given, the last path component is
 used as the name of the registry. If a name is given, it is created in
 the standard registry location. In both cases the registry path must
-not previously exist.
+not previously exist. The repository must be able to be pushed to,
+for example by being a bare repository.
 
 *Keyword arguments*
 


### PR DESCRIPTION
Add a few lines to README and `create_registry` docstring.