### PR TITLE
WIP: Add option to create a merge request for GitLab.

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -227,6 +227,7 @@ function do_register(package, registry;
 
     @info "Registering package" package_path registry_path package_repo uuid=pkg.uuid version=pkg.version tree_hash subdir
     clean_registry = true
+    clean_branch = false
 
     push_options = String[]
     if create_gitlab_mr
@@ -250,6 +251,7 @@ function do_register(package, registry;
             if commit
                 if !isnothing(branch)
                     run(`$git checkout -b $branch`)
+                    clean_branch = true
                 end
                 commit_registry(pkg, package_path, new_package,
                                 package_repo, tree_hash, git)
@@ -269,9 +271,9 @@ function do_register(package, registry;
             run(`$git reset --hard $(HEAD)`)
             run(`$git clean -f -d`)
             run(`$git checkout $(saved_branch)`)
-            if !isnothing(branch)
-                run(`$git branch -d $(branch)`)
-            end
+        end
+        if clean_branch
+            run(`$git branch -d $(branch)`)
         end
     end
 

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -605,9 +605,10 @@ function gitlab(branch, pkg, new_package, repo, commit)
     #
     # For the time being we use the workaround of replacing the
     # newlines with HTML `<br>` codes. This works but inhibits the
-    # markdown rendering of the list, so the result does not look
-    # great.
+    # markdown rendering of the list, so we also replace the markdown
+    # item indicators with unicode bullets to make it look a bit better.
     description = replace(description, "\n" => "<br>")
+    description = replace(description, "* " => "• ")
 
     push_options = ["-o", "merge_request.create"]
     push!(push_options, "-o", "merge_request.title=$title")

--- a/test/register.jl
+++ b/test/register.jl
@@ -243,3 +243,73 @@ with_testdir() do testdir
     @test readchomp(`$(upstream_git) log --format=%T:%s images`) == readchomp(`$(upstream2_git) log --format=%T:%s images`)
     @test length(readlines(`$(upstream2_git) log --format=%T:%s images`)) == 4
 end
+
+# Test automatic creation of a Gitlab merge request using git push options.
+# 1. Create a bare "upstream" repository.
+# 2. Create a new registry with the upstream as repo and `push = true`.
+# 3. Add a pre-receive hook to the upstream repository, which will save
+#    push options to a file.
+# 4. Register a package with `create_gitlab_mr = true`.
+# 5. Verify that the expected push options were received.
+with_testdir() do testdir
+    upstream_dir = joinpath(testdir, "upstream")
+    mkpath(upstream_dir)
+    upstream_git = gitcmd(upstream_dir, TEST_GITCONFIG)
+    run(`$(upstream_git) init --bare`)
+
+    registry_test_dir = joinpath(testdir, "TestGitlabMR")
+    create_registry(registry_test_dir, "file://$(upstream_dir)", push = true,
+                    gitconfig = TEST_GITCONFIG)
+
+    received_push_options_file = joinpath(testdir, "received_push_options")
+    run(`$(upstream_git) config --local receive.advertisePushOptions true`)
+    pre_receive_hook = joinpath(upstream_dir, "hooks", "pre-receive")
+    write(pre_receive_hook,
+          """
+          #!/bin/sh
+          if test -n "\$GIT_PUSH_OPTION_COUNT"
+          then
+              i=0
+              while test "\$i" -lt "\$GIT_PUSH_OPTION_COUNT"
+              do
+                  eval "value=\\\$GIT_PUSH_OPTION_\$i"
+                  echo \$value >> $(received_push_options_file)
+                  i=\$((i + 1))
+              done
+           fi
+           """)
+    chmod(pre_receive_hook, 0o775)
+
+    packages_dir = joinpath(testdir, "packages")
+    prepare_package(packages_dir, "FirstTest1.toml")
+    register(joinpath(packages_dir, "FirstTest"), registry = registry_test_dir,
+             push = true, create_gitlab_mr = true, gitconfig = TEST_GITCONFIG)
+
+    package_git = gitcmd(joinpath(packages_dir, "FirstTest"), TEST_GITCONFIG)
+    commit_hash = readchomp(`$(package_git) rev-parse HEAD`)
+    expected_push_options =
+        """
+        merge_request.create
+        merge_request.title=New package: FirstTest v1.0.0
+        merge_request.description=• Registering package: FirstTest<br>• Repository: git@example.com:Julia/FirstTest.jl.git<br>• Version: v1.0.0<br>• Commit: $(commit_hash)<br>
+        merge_request.merge_when_pipeline_succeeds
+        merge_request.remove_source_branch
+        """
+    # Obviously the hook shell script won't be effective on Windows,
+    # but there is no need to perform this test on every platform.
+    if !Sys.iswindows()
+        @test read(received_push_options_file, String) == expected_push_options
+    end
+    # Check that the automatically named branch exists in the upstream repo.
+    @test length(readchomp(`$(upstream_git) rev-parse --verify FirstTest/v1.0.0`)) == 40
+
+    # `create_gitlab_mr` requires `push` and `commit`.
+    @test_throws ErrorException register(joinpath(packages_dir, "FirstTest"),
+                                         registry = registry_test_dir,
+                                         push = false, create_gitlab_mr = true,
+                                         gitconfig = TEST_GITCONFIG)
+    @test_throws ErrorException register(joinpath(packages_dir, "FirstTest"),
+                                         registry = registry_test_dir,
+                                         commit = false, create_gitlab_mr = true,
+                                         gitconfig = TEST_GITCONFIG)
+end

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -1,4 +1,3 @@
-
 # The following tests are primarily regression tests - checking that
 # the results are the same as when the tests were written, regardless
 # of correctness.


### PR DESCRIPTION
This PR adds an option to `register` to automatically create a merge request if the registry is hosted on GitLab.

Why GitLab, what about GitHub, Bitbucket, etc? The reason is that GitLab supports creating a merge request with "git push options". This means two things:
1. LocalRegistry can use it without any additional dependencies, e.g. for talking to a git service provider's REST API.
2. No additional configuration or credentials are needed.

This is primarily intended for use in CI pipelines. The general idea is that when the conditions for a registration are met, the pipeline would run
```
julia -e 'using Pkg; Pkg.add("LocalRegistry")'
julia --project -e 'using LocalRegistry; register(registry = $REGISTRY_URL, create_gitlab_mr = true)'
```
The pipeline would need to have a write deploy key for the registry repository set up or credentials encoded within `REGISTRY_URL`.

Then the registry can e.g. be equipped with a CI job running RegistryCI and the merge request will be automatically merged once the CI passes.

There is one major limitation of this approach. Git push options do not support embedded newlines (probably they didn't want to get into the LF vs CRLF mire) and GitLab has no proper workaround for that (see https://gitlab.com/gitlab-org/gitlab/-/issues/241710), meaning that MR descriptions are severely handicapped. In fact to the extent that RegistryCI (at least the AutoMerge part) cannot handle it at this point.