### PR TITLE
Tag user in GitLab PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -596,6 +596,11 @@ function gitlab(branch, pkg, new_package, repo, commit)
     * Version: v$(pkg.version)
     * Commit: $(commit)
     """
+    # Tag the user who started the GitLab job
+    if haskey(ENV, "GITLAB_USER_LOGIN")
+        description = description * "* Triggered by: @$(ENV["GITLAB_USER_LOGIN"])\n"
+    end
+
 
     # Unfortunately git push options are not allowed to contain
     # newlines. This makes it difficult to create multiline


### PR DESCRIPTION
Following the discussion here https://github.com/GunnarFarneback/LocalRegistry.jl/pull/49#discussion_r806059413, I'm adding a line to the GitLab PR description, in order to tag the user who started the job (`GITLAB_USER_LOGIN` is the username of the user who started the job - see [GitLab documentation](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)).
This way the user can get notified about the progress of the PR to the registry, and attend to it e.g. if RegistryCI tests fail.

I tested this works as expected on our private GitLab instance.