### PR TITLE
Add support for creating a registry repo with an initial branch other than master.

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -37,11 +37,12 @@ for example by being a bare repository.
 
 *Keyword arguments*
 
-    create_registry(...; description = nothing, push = false, gitconfig = Dict())
+    create_registry(...; description = nothing, push = false, gitconfig = Dict(), branch = "master")
 
 * `description`: Optional description of the purpose of the registry.
 * `push`: If `false`, the registry will only be prepared locally. Review the result and `git push` it manually.
 * `gitconfig`: Optional configuration parameters for the `git` command.
+* `branch`: Name of the initial branch to use for the registry's repo.
 """
 function create_registry(name_or_path, repo; description = nothing,
                          gitconfig::Dict = Dict(), uuid = nothing,

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -45,7 +45,7 @@ for example by being a bare repository.
 """
 function create_registry(name_or_path, repo; description = nothing,
                          gitconfig::Dict = Dict(), uuid = nothing,
-                         push = false)
+                         push = false, branch = "master")
     if length(splitpath(name_or_path)) > 1
         path = abspath(expanduser(name_or_path))
     else
@@ -73,12 +73,12 @@ function create_registry(name_or_path, repo; description = nothing,
     RegistryTools.write_registry(joinpath(path, "Registry.toml"), registry_data)
 
     git = gitcmd(path, gitconfig)
-    run(`$git init -q`)
+    run(`$git init -q --initial-branch=$branch`)
     run(`$git add Registry.toml`)
     run(`$git commit -qm 'Create registry.'`)
     run(`$git remote add origin $repo`)
     if push
-        run(`$git push -u origin master`)
+        run(`$git push -u origin $branch`)
     end
     @info "Created registry in directory $(path)"
 


### PR DESCRIPTION
When an origin repo for a registry is created, it may use a branch name other than `master` (e.g., GitHub now defaults to `main`). When LocalRegistry creates a registry (e.g. in `~/.julia/registries/...`), it may use an inconsistent initial branch name, leading to errors on the first attempt to push. This PR adds an option for the initial branch name.

I tested this by creating a local repo as my "origin" (`git init --initial-branch=main --bare .`) and then using LocalRegistry to create a new registry using `main` as the initial branch and `file://...` as the URL (`create_registry("InitBranchTest5", "file:///Users/tucker/Dev/loreg/", branch = "main", push = true)`). This pushed correctly and appears to have done the right thing.

It still needs CI testing, so this is a draft PR so folks can provide feedback.

Possible improvements:

* The `--initial-branch` option will only work on git version 2.28.0, according to the same Stack Exchange. Perhaps this would be done after `git init` with `git checkout -b $branch`.
* The default initial branch name could be pulled from the system's git config (`git config --global init.defaultBranch` is suggested by [this Stack Exchange](https://stackoverflow.com/questions/42871542/how-can-i-create-a-git-repository-with-the-default-branch-name-other-than-maste), but it doesn't appear to work on my machine, so I didn't add a feature for this.)
