### PR TITLE
Drop support for Julia earlier than 1.6.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 CodecZlib = "0.5, 0.6, 0.7"
 RegistryTools = "2.0"
-julia = "~1.1, ~1.2, ~1.3, ~1.4, ~1.5, ~1.6, ~1.7, ~1.8"
+julia = "~1.6, ~1.7, ~1.8, ~1.9"
 
 [extras]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/test/register.jl
+++ b/test/register.jl
@@ -20,9 +20,9 @@ end
 with_empty_registry() do registry_dir, packages_dir
     prepare_package(packages_dir, "Broken1.toml")
     @test_throws ErrorException register(joinpath(packages_dir, "Broken"),
-                                                registry = registry_dir,
-                                                gitconfig = TEST_GITCONFIG,
-                                                push = false)
+                                         registry = registry_dir,
+                                         gitconfig = TEST_GITCONFIG,
+                                         push = false)
 end
 
 # Try to change name (UUID remains).

--- a/test/regression.jl
+++ b/test/regression.jl
@@ -14,11 +14,7 @@
 # project file is derived from this package.
 
 # Set up packages and registry directories in a temporary location.
-if VERSION >= v"1.2"
-    testdir = mktempdir(prefix = "LocalRegistryTests")
-else
-    testdir = mktempdir()
-end
+testdir = mktempdir(prefix = "LocalRegistryTests")
 packages_dir = joinpath(testdir, "packages")
 if packages_dir ∉ LOAD_PATH
     push!(LOAD_PATH, packages_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,3 @@ end
 @testset "Check git registry" begin
     include("check_git_registry.jl")
 end
-
-if VERSION < v"1.2"
-    rm(depot_path, recursive = true)
-end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -158,11 +158,7 @@ function sanity_check_registry(path)
 end
 
 function with_testdir(f::Function)
-    if VERSION >= v"1.2"
-        testdir = mktempdir(prefix = "LocalRegistryTests")
-    else
-        testdir = mktempdir()
-    end
+    testdir = mktempdir(prefix = "LocalRegistryTests")
     f(testdir)
     rm(testdir, recursive = true)
 end


### PR DESCRIPTION
Supporting Julia older than the current 1.6 LTS became untenable when RegistryTools raised compat in https://github.com/JuliaRegistries/RegistryTools.jl/pull/74. This allows some code simplifications.
