### PR TITLE
Create Registry in custom branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ companion package
 
 ## Compatibility
 
-This package requires Julia 1.1 or later.
+This package requires Julia 1.6 or later. Older versions of the
+package work back to Julia 1.1.
 
 ## Prerequisites
 
@@ -50,8 +51,9 @@ The repository at `repository_url` must be able to be pushed to,
 for example by being a bare repository. `repository_url` itself
 can be an URL, or a path to a local git repository.
 
-The registry can also be created at a specified path. See the
-documentation string for details.
+The registry can also be created at a specified path, with a specified
+branch, or being automatically pushed. See the documentation string
+for details.
 
 ## Add Registry
 

--- a/test/create_registry.jl
+++ b/test/create_registry.jl
@@ -1,0 +1,44 @@
+# Upstream and downstream have different ideas about initial branch
+# names. Respect upstream when no explicit branch name was set in the
+# `create_registry` call.
+with_testdir() do testdir
+    upstream_dir = joinpath(testdir, "upstream_registry")
+    mkpath(upstream_dir)
+    upstream_git = gitcmd(upstream_dir, TEST_GITCONFIG)
+    # With a sufficiently new git (probably 2.28) this test could be
+    # done much more easily, basically just
+    # run(`$upstream_git init -q --bare --initial_branch=some_unusual_branch_name`)
+    # To handle older git we have to first init the bare upstream
+    # repository, then clone a temporary downstream where we create a
+    # new branch, make a commit and push it up. Also needs some
+    # hacking of the original HEAD.
+    run(`$upstream_git init -q --bare`)
+    write(joinpath(upstream_dir, "HEAD"), "ref: refs/heads/some_unusual_branch_name")
+    tmp_downstream_dir = joinpath(testdir, "tmp_downstream")
+    mkpath(tmp_downstream_dir)
+    tmp_git = gitcmd(tmp_downstream_dir, TEST_GITCONFIG)
+    run(`$tmp_git clone file://$(upstream_dir) .`)
+    run(`$tmp_git checkout -b some_unusual_branch_name`)
+    write(joinpath(tmp_downstream_dir, ".gitignore"), "Manifest.toml")
+    run(`$tmp_git add .gitignore`)
+    run(`$tmp_git commit -m "Initial version"`)
+    run(`$tmp_git push -u origin some_unusual_branch_name`)
+
+    downstream_dir = joinpath(testdir, "downstream_registry")
+    create_registry(downstream_dir, "file://$(upstream_dir)", push = true,
+                    gitconfig = TEST_GITCONFIG)
+    @test readchomp(`$upstream_git branch --show-current`) == "some_unusual_branch_name"
+end
+
+# Test explicit branch name.
+with_testdir() do testdir
+    upstream_dir = joinpath(testdir, "upstream_registry")
+    mkpath(upstream_dir)
+    upstream_git = gitcmd(upstream_dir, TEST_GITCONFIG)
+    run(`$upstream_git init -q --bare`)
+    downstream_dir = joinpath(testdir, "downstream_registry")
+    create_registry(downstream_dir, "file://$(upstream_dir)", push = true,
+                    branch = "my_favorite_branch_name",
+                    gitconfig = TEST_GITCONFIG)
+    @test strip(read(`$upstream_git branch`, String)) == "my_favorite_branch_name"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,10 @@ Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
     include("regression.jl")
 end
 
+@testset "Create registry" begin
+    include("create_registry.jl")
+end
+
 @testset "Register tests" begin
     include("register.jl")
 end


### PR DESCRIPTION
Support registry creation in a specified branch and handle branch name more intuitively by default.

Fixes #54. Closes #58.