### PR TITLE
Reduce pkg internals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.5.3"
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodecZlib = "0.5, 0.6, 0.7"
+RegistryInstances = "0.1"
 RegistryTools = "2.0"
 julia = "~1.6, ~1.7, ~1.8, ~1.9, ~1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.5.3"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RegistryInstances = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
 RegistryTools = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
@@ -15,11 +14,12 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 CodecZlib = "0.5, 0.6, 0.7"
 RegistryInstances = "0.1"
 RegistryTools = "2.0"
-julia = "~1.6, ~1.7, ~1.8, ~1.9, ~1.10"
+julia = "1.6"
 
 [extras]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CodecZlib", "Test"]
+test = ["CodecZlib", "Pkg", "Test"]

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -393,7 +393,10 @@ function find_package_path(package_name::AbstractString)
     end
 
     manifest = get_current_manifest()
-    if VersionNumber(get(manifest, "manifest_format", "1")) > v"2.0"
+    manifest_format = VersionNumber(get(manifest, "manifest_format", "1"))
+    if manifest_format == v"1"
+        manifest = Dict("deps" => manifest)
+    elseif manifest_format > v"2.0"
         @warn("Unsupported manifest format, trying anyway.")
     end
     deps = manifest["deps"]

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -361,9 +361,12 @@ end
 # * use the active project if it corresponds to a package,
 # * otherwise use the current directory.
 function find_package_path(::Nothing)
-    project = Pkg.project()
-    if project.ispackage
-        return dirname(project.path)
+    path = Base.active_project()
+    project = TOML.parsefile(path)
+    # The active project is considered a package if it has a name and
+    # a uuid, which is the definition Pkg uses.
+    if haskey(project, "name") && haskey(project, "uuid")
+        return dirname(path)
     end
 
     return pwd()

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -16,7 +16,8 @@ using RegistryTools: RegistryTools, gitcmd, Compress,
                      check_and_update_registry_files, ReturnStatus, haserror,
                      find_registered_version, Project
 using UUIDs: uuid4
-using Pkg: Pkg, TOML
+import Pkg
+import TOML
 
 export create_registry, register
 
@@ -438,7 +439,7 @@ function find_registry_path(::Nothing, pkg::Project)
                                         all_registries)
 
     matching_registries = filter(all_registries) do reg_spec
-        reg_data = Pkg.TOML.parsefile(joinpath(reg_spec.path, "Registry.toml"))
+        reg_data = TOML.parsefile(joinpath(reg_spec.path, "Registry.toml"))
         haskey(reg_data["packages"], string(pkg.uuid))
     end
 
@@ -486,7 +487,7 @@ function check_git_registry(registry_path_or_url, gitconfig)
             elseif !isdir(registry_path_or_url)
                 error("Bad registry path: $(registry_path_or_url)")
             end
-            url = Pkg.TOML.parsefile(joinpath(registry_path_or_url, "Registry.toml"))["repo"]
+            url = TOML.parsefile(joinpath(registry_path_or_url, "Registry.toml"))["repo"]
         end
     end
 
@@ -507,7 +508,7 @@ function looks_like_tar_registry(path)
     endswith(path, ".toml") || return false
     isfile(path) || return false
     try
-        return haskey(Pkg.TOML.parsefile(path), "git-tree-sha1")
+        return haskey(TOML.parsefile(path), "git-tree-sha1")
     catch
         return false
     end
@@ -544,7 +545,7 @@ function collect_registries()
 end
 
 function has_package(registry_path, pkg::Project)
-    registry = Pkg.TOML.parsefile(joinpath(registry_path, "Registry.toml"))
+    registry = TOML.parsefile(joinpath(registry_path, "Registry.toml"))
     return haskey(registry["packages"], string(pkg.uuid))
 end
 

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -17,7 +17,6 @@ using RegistryTools: RegistryTools, gitcmd, Compress,
                      find_registered_version, Project
 using RegistryInstances: RegistryInstance, reachable_registries
 using UUIDs: uuid4
-import Pkg
 import TOML
 
 export create_registry, register

--- a/test/check_git_registry.jl
+++ b/test/check_git_registry.jl
@@ -39,12 +39,7 @@ with_testdir() do testdir
              uuid = "ed6ca2f6-392d-11ea-3224-d3daf7fee369"
              path = "TestRegistry.tar.gz"
           """)
-    if VERSION < v"1.7-"
-        @test_throws ErrorException check_git_registry(registry_toml,
-                                                       TEST_GITCONFIG)
-    else
-        reg_path, is_temp = check_git_registry(registry_toml, TEST_GITCONFIG)
-        @test isdir(joinpath(reg_path, ".git"))
-        @test is_temp
-    end
+    reg_path, is_temp = check_git_registry(registry_toml, TEST_GITCONFIG)
+    @test isdir(joinpath(reg_path, ".git"))
+    @test is_temp
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,6 @@
 using RegistryTools: gitcmd, Compress
-using Pkg: Pkg, TOML
+import Pkg
+import TOML
 
 # Read `project_file` and create or update a corresponding bare bones
 # package directory under `package_dir`. Commit the changes to git.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,6 +2,7 @@
 
 using LocalRegistry: gitcmd
 using RegistryTools: Compress
+using RegistryInstances: RegistryInstance
 import Pkg
 import TOML
 
@@ -122,10 +123,7 @@ end
 function sanity_check_registry(path)
     registry = TOML.parsefile(joinpath(path, "Registry.toml"))
     if VERSION >= v"1.7-"
-        # TODO: Check if the `parse_packages` keyword is available
-        # when the final Julia 1.7 has been released and if so set it
-        # explicitly to true.
-        registry = Pkg.Registry.RegistryInstance(path)  # , parse_packages = true)
+        registry = RegistryInstance(path)
         return true
     end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,7 @@
-using RegistryTools: gitcmd, Compress
+# Note: This file is also included by LocalPackageServer tests.
+
+using LocalRegistry: gitcmd
+using RegistryTools: Compress
 import Pkg
 import TOML
 


### PR DESCRIPTION
Remove dependencies on Pkg internals, except in tests. With this the upper bound on minor Julia versions is dropped.
