### PR TITLE
Bugfix for 0.5.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalRegistry"
 uuid = "89398ba2-070a-4b16-a995-9893c55d93cf"
 authors = ["Gunnar Farnebäck <gunnar@lysator.liu.se>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -208,7 +208,6 @@ function do_register(package, registry;
         error("$(package) is not a valid package (no src/$(pkg_filename))")
     end
 
-
     # If the package directory is dirty, a different version could be
     # present in Project.toml.
     if is_dirty(package_path, gitconfig)
@@ -458,8 +457,7 @@ function find_registry_path(::Nothing, pkg::Project)
                                         all_registries)
 
     matching_registries = filter(all_registries) do reg_spec
-        reg_data = TOML.parsefile(joinpath(reg_spec.path, "Registry.toml"))
-        haskey(reg_data["packages"], string(pkg.uuid))
+        haskey(reg_spec.pkgs, pkg.uuid)
     end
 
     if isempty(matching_registries)


### PR DESCRIPTION
Unfortunately 0.5.4 contains a bug which causes errors when there are registries installed which are not unpacked. (Which is the default for current Julia versions, so extra bad.)

This fixes it by using the output from `RegistryInstances.reachable_registries` in a better way.
