### PR TITLE
Avoid clobbering existing repositories & README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,25 @@ pkg"add LocalRegistry"
 
 ## Create Registry
 
+Before `LocalRegistry` can create a registry, you need to have a `git`
+repository in which `LocalRegistry` will create the new registry. You must
+be able to push to this repository, so typically it is created either by
+using `git init --bare` or by creating it on a service such as *GitHub*.
+No content is required in this repository, in fact certain content may
+cause future problems.
+
+The Julia code for creating a registry can be:
 ```
 using LocalRegistry
 create_registry(name, repository_url, description = "My private registry")
 ```
 This prepares a registry with the given name in the standard
-location for registries. Review the result and `git push` it
+location for registries (the default location is
+`~/.julia/registries/`). Review the result and `git push` it
 manually. When created in this way the registry is automatically
 activated and the next section can be skipped.
 
-The repository at `repository_url` must be able to be pushed to,
-for example by being a bare repository. `repository_url` itself
+`repository_url` refers to the git repository mentioned above and
 can be an URL, or a path to a local git repository.
 
 The registry can also be created at a specified path, with a specified

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -81,6 +81,12 @@ function create_registry(name_or_path, repo; description = nothing,
             git_repo_cloned = true
         catch
         end
+        # We do not want to clobber existing registries
+        if ispath(joinpath(path, "Registry.toml"))
+            @warn("$repo already contains a registry, this registry was added, no new registry was created")
+            # TODO: Handle the case when `name_or_path` does not match the name in Registry.toml
+            return path
+        end
     end
 
     # The only reason for the `uuid` keyword argument is to allow

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -82,10 +82,8 @@ function create_registry(name_or_path, repo; description = nothing,
         catch
         end
         # We do not want to clobber existing registries
-        if ispath(joinpath(path, "Registry.toml"))
-            @warn("$repo already contains a registry, this registry was added, no new registry was created")
-            # TODO: Handle the case when `name_or_path` does not match the name in Registry.toml
-            return path
+        if ispath(joinpath(path, "Registry.toml")) && isnothing(branch)
+            error("$repo already contains a registry")
         end
     end
 

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -45,7 +45,8 @@ for example by being a bare repository.
 * `push`: If `false`, the registry will only be prepared locally.
   Review the result and `git push` it manually. If `true`, the upstream
   repository is first cloned (if possible) before creating the registry.
-* `branch`: Create the registry in the specified branch. Default is to
+* `branch`: Create the registry in the specified branch (the branch must
+  not exist). Default is to
   use the upstream branch if `push` is `true` and otherwise the default
   branch name configured for `git init`.
 * `gitconfig`: Optional configuration parameters for the `git` command.

--- a/test/create_registry.jl
+++ b/test/create_registry.jl
@@ -28,6 +28,12 @@ with_testdir() do testdir
     create_registry(downstream_dir, "file://$(upstream_dir)", push = true,
                     gitconfig = TEST_GITCONFIG)
     @test readchomp(`$upstream_git branch --show-current`) == "some_unusual_branch_name"
+
+    # Test that `create_registry` errors rather than overwriting an existing registry
+    run(`rm -rf $(downstream_dir)`)
+    @test_throws ErrorException("file://$(upstream_dir) already contains a registry") (
+                    create_registry(downstream_dir, "file://$(upstream_dir)",
+                                    push = true, gitconfig = TEST_GITCONFIG))
 end
 
 # Test explicit branch name.
@@ -41,4 +47,11 @@ with_testdir() do testdir
                     branch = "my_favorite_branch_name",
                     gitconfig = TEST_GITCONFIG)
     @test strip(read(`$upstream_git branch`, String)) == "my_favorite_branch_name"
+
+    # Test that `create_registry` errors rather than overwriting an existing registry
+    run(`rm -rf $(downstream_dir)`)
+    @test_throws ProcessFailedException (
+                    create_registry(downstream_dir, "file://$(upstream_dir)",
+                                    branch = "my_favorite_branch_name",
+                                    push = true, gitconfig = TEST_GITCONFIG))
 end


### PR DESCRIPTION
When creating a new registry in a repository that already contains a registry, the existing registry is (partially) overwritten. When this happens, I would expect that it often is a mistake; This proposed change in src/LocalRepository.jl prevents this.

There are also some proposed changes to the README.md to make it easier for new users to understand how to create a repository.

I would like to hear your opinion on these proposed changes. I am of course willing to fix the TODO if you feel that this proposal is a step in the right direction.