### PR TITLE
Reorganize README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,98 +33,51 @@ you are good to go.
 
 ```
 using Pkg
-pkg"add LocalRegistry"
+Pkg.add("LocalRegistry")
 ```
 
 ## Create Registry
 
-Before `LocalRegistry` can create a registry, you need to have a `git`
-repository in which `LocalRegistry` will create the new registry. You must
-be able to push to this repository, so typically it is created either by
-using `git init --bare` or by creating it on a service such as *GitHub*.
-No content is required in this repository, in fact certain content may
-cause future problems.
-
-The Julia code for creating a registry can be:
+The recommended way to create a registry is
 ```
 using LocalRegistry
-create_registry(name, repository_url, description = "My private registry")
+create_registry(name, repository_url; description = "My private registry", push = true)
 ```
-This prepares a registry with the given name in the standard
-location for registries (the default location is
-`~/.julia/registries/`). Review the result and `git push` it
-manually. When created in this way the registry is automatically
-activated and the next section can be skipped.
+where `name` is the name of your registry and `repository_url` points
+to an *empty* upstream repository where you will host your registry.
 
-`repository_url` refers to the git repository mentioned above and
-can be an URL, or a path to a local git repository.
-
-The registry can also be created at a specified path, with a specified
-branch, or being automatically pushed. See the documentation string
-for details.
+There are a number of options to customize this. Read more about that
+and further explanations in the [detailed
+instructions](docs/create_registry.md).
 
 ## Add Registry
 
 To activate the registry, do
 ```
 using Pkg
-pkg"registry add <repository url>"
+Pkg.Registry.add(repository_url)
 ```
 This only needs to be done once per Julia installation.
 [Troubleshooting advice](docs/troubleshooting_general.md) if you
 cannot find packages from the General registry.
 
-## Register a Package
+## Register a Package or a New Version of a Package
 
-```
-using LocalRegistry
-register(package; registry = registry)
-```
-
-Register the new `package` in the registry `registry`. The version
-number and other information is obtained from the package's
-`Project.toml`. The easiest way to specify `package` and `registry` is
-by name as strings. See the documentation string for more options.
-
-Notes:
-* You need to have a clean working copy of your registry.
-* The package must be stored as a git working copy, e.g. having been
-  cloned with `Pkg.develop`.
-* The package must be available in the current `Pkg` environment.
-* The package must have a `Project.toml` or `JuliaProject.toml` file.
-* There is no checking that the dependencies are available in any
-  registry.
-* If you have exactly one installed registry beside the `General`
-  registry, it is not necessary to specify `registry`.
-* By default the registry changes are `git push`ed to the upstream
-  registry repository.
-
-## Register a New Version of a Package
-
-```
-using LocalRegistry
-register(package)
-```
-
-When adding a new version of a package, the registry can be
-omitted. The new version number is obtained from the `version` field
-of the package's `Project.toml` file.
-
-## Simplified Registration of Active Package or Current Directory
-
-If you start Julia with the `--project` flag or use `Pkg.activate` to
-activate a developed package, this package can be registered simply by
+The recommended way to register a package or a new version of a
+package is simply:
 
 ```
 using LocalRegistry
 register()
 ```
 
-This is also sufficient for registering a new package, provided that
-you have exactly one installed registry beside the `General` registry.
+For this to work you need to either have the package in your current
+directory or have the package activated.
 
-If you run `register()` but the active project is not a package, it
-will look for a package in the current directory.
+Actually there are some more requirements but those are usually
+satisfied. Read more about that, a number of options to customize the
+call, and some additional features in the [detailed
+instructions](docs/register.md).
 
 ## Advanced Topics
 

--- a/docs/create_registry.md
+++ b/docs/create_registry.md
@@ -1,0 +1,83 @@
+# Create Registry
+
+The full set of arguments to `create_registry` is
+```
+create_registry(name_or_path, repository_url;
+                description, push, branch, git_config)
+```
+
+## Positional Arguments
+
+`name_or_path::AbstractString`:
+
+The name and location (on local storage) of your new registry can be
+specified in two different ways. The recommended way is to specify it
+by name. In that case it is created in the standard place for
+registries, typically `~/.julia/registries`, and will be automatically
+available as an installed registry. The second option is to specify it
+by path, in which case the last component of the path is used as the
+registry name. If you want to create a registry in your current
+directory, specify the path with a leading `"./"` to disambiguate it
+from a registry name.
+
+`repository_url::AbstractString`:
+
+Normally `repository_url` should be the URL to an existing but empty
+repository on some git hosting service, e.g. GitHub or GitLab, but it
+can also be a bare repository on local storage. In order to work
+properly you need to be able to push to the registry, which may
+involve ssh keys or other credentials.
+
+Notes:
+
+* When creating the repository on a git hosting service, it is
+  recommended to unmark all options to initialize the repo with
+  various content.
+
+* For URLs to local storage, it is recommended to use the [File URI
+  scheme](https://en.wikipedia.org/wiki/File_URI_scheme),
+  e.g. `file:///home/user/registry`.
+
+* If you want to create a bare repository, use `git init --bare`.
+  Normal repositories are not advisable to use as targets for push
+  operations.
+
+* If you should want to only use the registry on a single computer and
+  not have an upstream repository at all, you can set `repository_url`
+  to a fake URL and use the keyword argument `push = false` with both
+  the `create_registry` and `register` functions.
+
+## Keyword Arguments
+
+`description::Union{Nothing, AbstractString}`:
+
+Free text description of the registry. This is stored in the top level
+file `Registry.toml` but is currently neither used, nor exposed, by
+the package manager. Defaults to `nothing`, meaning that it is
+omitted.
+
+`push::Bool`:
+
+Whether to `git push` the created registry to the upstream repository
+specified by `repository_url`. If `false` you need to do the `git
+push` manually, but gives you opportunity to review the result before
+pushing it. Defaults to `false`.
+
+**Note: The default will likely be changed to `true` in a future
+breaking release.**
+
+`branch::Union{Nothing, AbstractString}`:
+
+What branch to use for the registry in the repository. Defaults to
+`nothing`, in which case the branch name is decided by:
+
+* If `push` is true, the default branch in the upstream repository is
+  used, if the repository exists and can be cloned.
+
+* Otherwise the default branch for the local `git` is used.
+
+`git_config::Dict{<:AbstractString, <:AbstractString}`:
+
+Optional configuration parameters for the `git` command. For
+interactive use you most likely do not need this. Defaults to
+an empty dictionary, i.e. no configuration.

--- a/docs/register.md
+++ b/docs/register.md
@@ -1,0 +1,143 @@
+# Register a Package or a New Version of a Package
+
+Registration of a new package or a new version of a previously
+registered package are both done with the `register` function.
+
+The full set of arguments to `register` is
+```
+register(package = nothing;
+         registry, commit, push, repo, ignore_reregistration,
+         gitconfig, create_gitlab_mr)
+```
+
+although in many cases a no-argument `register()` call is sufficient.
+
+Notice that LocalRegistry should be installed in the global
+environment or in some shared environment. It should never be a
+dependency of the package you want to register, unless the package
+wraps or extends LocalRegistry functionality.
+
+## Positional Argument
+
+`package::Union{Nothing, Module, AbstractString}`:
+
+The package to be registered can be specified in several ways.
+
+* If `package` is omitted or `nothing`, the active project is used if
+  it is a package. Otherwise the current directory is used if that
+  contains a package.
+
+* If `package` is a `Module`, that is used. It needs to first be
+  loaded by `using` or `import`.
+
+* If `package` is a string, it can be either a package name or a
+  path. It is considered a path if it contains multiple path
+  components. A path in the current working directory can be specified
+  by starting with `"./"`. If it is a name, it must be available in
+  the active environment.
+
+Notes:
+
+* To activate a package, either use the `Pkg.activate` function or
+  start Julia with the `--project` flag.
+
+* The package must be stored as a git working copy, e.g. having been
+  cloned with `Pkg.develop`, and must not contain un-committed
+  changes.
+
+* The package must have a `Project.toml` or `JuliaProject.toml`
+  file. This must include `name`, `uuid`, and `version` fields.
+
+* To register a new version, the `version` field in `Project.toml`
+  must be updated.
+
+* There is no checking that the package's dependencies are available
+  in some registry. This can be separately verified with [registry
+  consistency testing](registry_ci.md).
+
+## Keyword Arguments
+
+`registry::Union{Nothing, AbstractString}`:
+
+There are a number of ways to specify the registry to register the
+package in.
+
+* If `registry` is omitted or `nothing`, it is first checked if the
+  package is already registered in exactly one of the installed
+  registries, in which case the new version is also registered there.
+  In case of a new package, there must be exactly one installed
+  registry, which is not General, and that is used.
+
+* If `registry` is a string, the first match below is used.
+  * It is considered a registry name if it is an exact match for one of
+    the installed registries.
+  * It is considered a path if it is an existing path on the local
+    file system.
+  * Otherwise it is assumed to be a URL to an upstream registry.
+
+Notes:
+
+* LocalRegistry needs to work with a git clone of the registry. If
+  that is not already the case, or `registry` is specified as a URL, a
+  temporary git clone is made for the registration. This requires that
+  both keyword arguments `commit` and `push` are `true`.
+
+* The registry must not have any un-committed changes, unless the
+  keyword argument `commit` is `false`.
+
+`commit::Bool`:
+
+Whether to `git commit` the changes made to the registry. Default is
+`true`. Only set it to `false` if you are doing something unusual and
+know that it's needed.
+
+`push::Bool`:
+
+Whether to push the commits to the upstream repository. Default is
+true. Setting it to `false` is mostly useful if you want to inspect
+the commits before manually pushing, or if you have decided not to
+have an upstream repository. It cannot be set to `true` if the keyword
+argument `commit` is `false`.
+
+`repo::Union{Nothing, AbstractString}`:
+
+URL to the package repository. This is stored in the registry.
+
+* If `repo` is omitted or `nothing`:
+  * If it is a new version of a previously registered package, do not
+    update the repo location.
+  * If it is a new package, look up the URL from the package's `git
+    remote`.
+
+* If it is a string, set or update the repo location in the registry
+  with the given string.
+
+`ignore_reregistration::Bool`:
+
+Whether not to give an error if trying to register a previously
+registered version of the package, unless it is identical to the
+registered version. Defaults to `false`. If `true`, only print an
+informational message.
+
+**Note: The default will likely be changed to `true` in a future update.**
+
+`git_config::Dict{<:AbstractString, <:AbstractString}`:
+
+Optional configuration parameters for the `git` command. For
+interactive use you most likely do not need this. Defaults to
+an empty dictionary, i.e. no configuration.
+
+For CI purposes it can be useful, e.g. as used in the LocalRegistry
+tests:
+```
+git_config = Dict("user.name" => "LocalRegistryTests",
+                  "user.email" => "localregistrytests@example.com")
+```
+
+`create_gitlab_mr`:
+
+If `true`, send git push options to create a GitLab merge
+request. Requires the keyword arguments `commit` and `push` to both be
+`true`. Default is `false`. This functionality is mostly useful as
+part of package CI if hosted on GitLab, to automatically register
+packages.

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -45,6 +45,7 @@ for example by being a bare repository.
 * `push`: If `false`, the registry will only be prepared locally.
   Review the result and `git push` it manually. If `true`, the upstream
   repository is first cloned (if possible) before creating the registry.
+  Defaults to `false` but may be changed to `true` in the future.
 * `branch`: Create the registry in the specified branch (the branch must
   not exist). Default is to
   use the upstream branch if `push` is `true` and otherwise the default
@@ -171,7 +172,7 @@ will be used to perform the registration. In this case `push` must be
 * `push`: If `true`, push the changes to the registry repository automatically. Ignored if `commit` is false.
 * `branch`: Branch name to use for the registration.
 * `repo`: Specify the package repository explicitly. Otherwise looked up as the `git remote` of the package the first time it is registered.
-* `ignore_reregistration`: If `true`, do not raise an error if a version has already been registered (with different content), only an informational message.
+* `ignore_reregistration`: If `true`, do not raise an error if a version has already been registered (with different content), only an informational message. Defaults to `false` but may be changed to `true` in the future.
 * `gitconfig`: Optional configuration parameters for the `git` command.
 * `create_gitlab_mr`: If `true` sends git push options to create a GitLab merge request. Requires `commit` and `push` to be true.
 """


### PR DESCRIPTION
The README spent far too much space discussing complications and generalizations. This PR moves the complicated stuff into separate pages for `create_registry` and `register`, leaving the typical and easy use cases in the README.