### PR TITLE
allow registering from a dirty repo

### DIFF
--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -187,6 +187,7 @@ end
 # `registry`. Also returns false if there was nothing new to register
 # and true if something new was registered.
 function do_register(package, registry;
+                     allow_dirty=false,
                      commit = true, push = true, branch = nothing,
                      repo = nothing, ignore_reregistration = false,
                      gitconfig::Dict = Dict(), create_gitlab_mr = false)
@@ -217,7 +218,9 @@ function do_register(package, registry;
     # If the package directory is dirty, a different version could be
     # present in Project.toml.
     if is_dirty(package_path, gitconfig)
-        error("Package directory is dirty. Stash or commit files.")
+        allow_dirty ?
+            error("Package directory is dirty. Stash or commit files.") :
+            @info "Note: package directory is dirty."
     end
 
     registry_path = find_registry_path(registry, pkg)
@@ -226,7 +229,7 @@ function do_register(package, registry;
         error("Need to use a temporary git clone of the registry, but commit or push is set to false.")
     end
     if is_dirty(registry_path, gitconfig)
-        if commit
+        if !allow_dirty && commit
             error("Registry directory is dirty. Stash or commit files.")
         else
             @info("Note: registry directory is dirty.")

--- a/src/LocalRegistry.jl
+++ b/src/LocalRegistry.jl
@@ -188,9 +188,8 @@ end
 # `registry`. Also returns false if there was nothing new to register
 # and true if something new was registered.
 function do_register(package, registry;
-                     allow_package_dirty=false,
                      commit = true, push = true, branch = nothing,
-                     repo = nothing, ignore_reregistration = false,
+                     repo = nothing, ignore_reregistration = false, allow_package_dirty = false,
                      gitconfig::Dict = Dict(), create_gitlab_mr = false)
     # Find and read the `Project.toml` for the package. First look for
     # the alternative `JuliaProject.toml`.
@@ -219,7 +218,7 @@ function do_register(package, registry;
     # If the package directory is dirty, a different version could be
     # present in Project.toml.
     if is_dirty(package_path, gitconfig)
-        allow_package_dirty ?
+        !allow_package_dirty ?
             error("Package directory is dirty. Stash or commit files.") :
             @info "Note: package directory is dirty."
     end

--- a/test/register.jl
+++ b/test/register.jl
@@ -161,6 +161,12 @@ with_empty_registry() do registry_dir, packages_dir
                                          registry = registry_dir,
                                          gitconfig = TEST_GITCONFIG,
                                          push = false)
+    register(joinpath(packages_dir, "Flux"),
+             registry = registry_dir,
+             gitconfig = TEST_GITCONFIG,
+             push = false,
+             allow_package_dirty = true)
+    @test isfile(joinpath(registry_dir, "F", "Flux", "Package.toml"))
 end
 
 # Dirty the registry repository and try to register a package.


### PR DESCRIPTION
I often want to register a package dir that is dirty – typically, when I have some example notebooks in the dir and playing with them. In the simplest case, it requires manually stashing & unstashing changes. But even this doesn't always work when notebooks are currently open in Pluto because it updates some fields such as version continuously.

Would be nice to add a flag like `allow_dirty` (open to name suggestions) that would just register the current commit and ignore the git repo being dirty.

Will add a test if this addition is welcome!